### PR TITLE
feat: add CF analytics script directly to built HTML

### DIFF
--- a/src/html.tsx
+++ b/src/html.tsx
@@ -9,7 +9,7 @@ const HTML: React.FC<Props> = props => {
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 
         {/* <!-- Cloudflare Web Analytics --> */}
-        <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "02248a7178184dfea7dd8abd1639759b"}' />
+        <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "24bc94c5419241dcafa5223c7cd712e2"}' />
 
         {props.headComponents}
       </head>


### PR DESCRIPTION
Previously, Cloudflare auto-injected this for us, but I found this was also injecting it on all other CF-proxied subdomains despite them not matching the hostname I provided.

I only really want analytics for my portfolio site anyway, so manually configuring the web analytics seems like the best choice.